### PR TITLE
fix: bug in the dfs logic

### DIFF
--- a/src/app/services/item_service.py
+++ b/src/app/services/item_service.py
@@ -228,7 +228,7 @@ def get_item_by_id_dfs_iterative(
 
                     for task in lab.tasks:
                         counter += 1
-                        if lab.id == item_id:
+                        if task.id == item_id:
                             return FoundItem(task, counter)
 
                         for step in task.steps:


### PR DESCRIPTION
- task.id was never checked

<!-- Provide a general summary of your changes in the Title above -->

## Summary

This PR fixes a critical logic error in the iterative DFS implementation:ё

1. The Problem: The code was comparing lab.id instead of task.id during task iteration.
2. The Result: This caused a 404 Not Found error in tests when searching for specific tasks.
3. The Fix: Updated the condition to correctly verify task.id.

- Closes #3

---

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I made this PR to the main branch of my fork.
- [x] I see base: main <- compare: fix/dfs-bug
- [x] I edited the line - Closes #3.
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the changes I’m submitting.
